### PR TITLE
fix the boolean blindness of edgeExists

### DIFF
--- a/src/Data/Graph/Haggle.hs
+++ b/src/Data/Graph/Haggle.hs
@@ -131,6 +131,7 @@ module Data.Graph.Haggle (
   edges,
   successors,
   outEdges,
+  edgesBetween,
   edgeExists,
   isEmpty,
   thaw,
@@ -298,6 +299,10 @@ successors = I.successors
 outEdges :: (I.Graph g) => g -> I.Vertex -> [I.Edge]
 outEdges = I.outEdges
 {-# INLINABLE outEdges #-}
+
+edgesBetween :: (I.Graph g) => g -> I.Vertex -> I.Vertex -> [I.Edge]
+edgesBetween = I.edgesBetween
+{-# INLINABLE edgesBetween #-}
 
 edgeExists :: (I.Graph g) => g -> I.Vertex -> I.Vertex -> Bool
 edgeExists = I.edgeExists

--- a/src/Data/Graph/Haggle/BiDigraph.hs
+++ b/src/Data/Graph/Haggle/BiDigraph.hs
@@ -204,9 +204,9 @@ instance Graph BiDigraph where
     | otherwise =
       let succs = V.unsafeIndex (graphSuccs g) v
       in concat (IM.elems succs)
-  edgeExists g (V src) (V dst)
-    | outOfRange g src || outOfRange g dst = False
-    | otherwise = IM.member dst (V.unsafeIndex (graphSuccs g) src)
+  edgesBetween g (V src) (V dst)
+    | outOfRange g src || outOfRange g dst = []
+    | otherwise = IM.findWithDefault [] dst (V.unsafeIndex (graphSuccs g) src)
   maxVertexId g = V.length (graphSuccs g) - 1
   isEmpty = (==0) . vertexCount
 

--- a/src/Data/Graph/Haggle/Classes.hs
+++ b/src/Data/Graph/Haggle/Classes.hs
@@ -16,6 +16,7 @@ module Data.Graph.Haggle.Classes (
   MLabeledVertex(..),
   -- * Immutable Graphs
   Graph(..),
+  edgeExists,
   Thawable(..),
   Bidirectional(..),
   HasEdgeLabel(..),
@@ -116,9 +117,16 @@ class Graph g where
   edges :: g -> [Edge]
   successors :: g -> Vertex -> [Vertex]
   outEdges :: g -> Vertex -> [Edge]
-  edgeExists :: g -> Vertex -> Vertex -> Bool
   maxVertexId :: g -> Int
   isEmpty :: g -> Bool
+  -- | This has a default implementation in terms of 'outEdges', but is part
+  -- of the class so that instances can offer a more efficient implementation
+  -- when possible.
+  edgesBetween :: g -> Vertex -> Vertex -> [Edge]
+  edgesBetween g src dst = filter ((dst ==) . edgeDest) (outEdges g src)
+
+edgeExists :: Graph g => g -> Vertex -> Vertex -> Bool
+edgeExists g v1 v2 = not . null $ edgesBetween g v1 v2
 
 class (Graph g) => Thawable g where
   type MutableGraph g :: (* -> *) -> *

--- a/src/Data/Graph/Haggle/Digraph.hs
+++ b/src/Data/Graph/Haggle/Digraph.hs
@@ -178,7 +178,6 @@ instance Graph Digraph where
     | otherwise =
       let root = UV.unsafeIndex (edgeRoots g) v
       in pureEdges g v root
-  edgeExists g v1 v2 = any (==v2) $ successors g v1
   maxVertexId g = UV.length (edgeRoots g) - 1
   isEmpty = (==0) . UV.length . edgeRoots
 

--- a/src/Data/Graph/Haggle/EdgeLabelAdapter.hs
+++ b/src/Data/Graph/Haggle/EdgeLabelAdapter.hs
@@ -39,9 +39,9 @@ outEdges :: (I.Graph g) => EdgeLabeledGraph g el -> I.Vertex -> [I.Edge]
 outEdges (ELG lg) = I.outEdges lg
 {-# INLINE outEdges #-}
 
-edgeExists :: (I.Graph g) => EdgeLabeledGraph g el -> I.Vertex -> I.Vertex -> Bool
-edgeExists (ELG lg) = I.edgeExists lg
-{-# INLINE edgeExists #-}
+edgesBetween :: (I.Graph g) => EdgeLabeledGraph g el -> I.Vertex -> I.Vertex -> [I.Edge]
+edgesBetween (ELG lg) = I.edgesBetween lg
+{-# INLINE edgesBetween #-}
 
 maxVertexId :: (I.Graph g) => EdgeLabeledGraph g el -> Int
 maxVertexId = I.maxVertexId . unELG
@@ -56,7 +56,7 @@ instance (I.Graph g) => I.Graph (EdgeLabeledGraph g el) where
   edges = edges
   successors = successors
   outEdges = outEdges
-  edgeExists = edgeExists
+  edgesBetween = edgesBetween
   maxVertexId = maxVertexId
   isEmpty = isEmpty
 

--- a/src/Data/Graph/Haggle/Internal/Adapter.hs
+++ b/src/Data/Graph/Haggle/Internal/Adapter.hs
@@ -241,9 +241,9 @@ outEdges :: (I.Graph g) => LabeledGraph g nl el -> I.Vertex -> [I.Edge]
 outEdges lg = I.outEdges (rawGraph lg)
 {-# INLINE outEdges #-}
 
-edgeExists :: (I.Graph g) => LabeledGraph g nl el -> I.Vertex -> I.Vertex -> Bool
-edgeExists lg = I.edgeExists (rawGraph lg)
-{-# INLINE edgeExists #-}
+edgesBetween :: (I.Graph g) => LabeledGraph g nl el -> I.Vertex -> I.Vertex -> [I.Edge]
+edgesBetween lg = I.edgesBetween (rawGraph lg)
+{-# INLINE edgesBetween #-}
 
 maxVertexId :: (I.Graph g) => LabeledGraph g nl el -> Int
 maxVertexId = I.maxVertexId . rawGraph
@@ -276,7 +276,7 @@ instance (I.Graph g) => I.Graph (LabeledGraph g nl el) where
   edges = edges
   successors = successors
   outEdges = outEdges
-  edgeExists = edgeExists
+  edgesBetween = edgesBetween
   maxVertexId = maxVertexId
   isEmpty = isEmpty
 

--- a/src/Data/Graph/Haggle/PatriciaTree.hs
+++ b/src/Data/Graph/Haggle/PatriciaTree.hs
@@ -7,6 +7,7 @@ module Data.Graph.Haggle.PatriciaTree ( PatriciaTree ) where
 
 import Control.DeepSeq
 import Control.Monad ( guard )
+import Data.Foldable ( toList )
 import Data.IntMap ( IntMap )
 import qualified Data.IntMap as IM
 import Data.Maybe ( fromMaybe )
@@ -43,9 +44,10 @@ instance I.Graph (PatriciaTree nl el) where
   maxVertexId (Gr g)
     | IM.null g = 0
     | otherwise = fst $ IM.findMax g
-  edgeExists (Gr g) (I.V src) (I.V dst) = fromMaybe False $ do
+  edgesBetween (Gr g) (I.V src) (I.V dst) = toList $ do
     Ctx _ _ _ ss <- IM.lookup src g
-    return $ IM.member dst ss
+    guard (IM.member dst ss)
+    return (I.E (-1) src dst)
   edges g = concatMap (I.outEdges g) (I.vertices g)
   successors (Gr g) (I.V v) = fromMaybe [] $ do
     Ctx _ _ _ ss <- IM.lookup v g

--- a/src/Data/Graph/Haggle/SimpleBiDigraph.hs
+++ b/src/Data/Graph/Haggle/SimpleBiDigraph.hs
@@ -13,6 +13,7 @@ module Data.Graph.Haggle.SimpleBiDigraph (
 import Control.Monad ( when )
 import qualified Control.Monad.Primitive as P
 import qualified Control.Monad.Ref as R
+import Data.Foldable ( toList )
 import Data.IntMap ( IntMap )
 import qualified Data.IntMap as IM
 import qualified Data.Vector.Mutable as MV
@@ -185,9 +186,9 @@ instance Graph SimpleBiDigraph where
     | otherwise =
       let succs = V.unsafeIndex (graphSuccs g) v
       in IM.elems succs
-  edgeExists g (V src) (V dst)
-    | outOfRange g src || outOfRange g dst = False
-    | otherwise = IM.member dst (V.unsafeIndex (graphSuccs g) src)
+  edgesBetween g (V src) (V dst)
+    | outOfRange g src || outOfRange g dst = []
+    | otherwise = toList $ IM.lookup dst (V.unsafeIndex (graphSuccs g) src)
   maxVertexId g = V.length (graphSuccs g) - 1
   isEmpty = (==0) . vertexCount
 

--- a/src/Data/Graph/Haggle/VertexLabelAdapter.hs
+++ b/src/Data/Graph/Haggle/VertexLabelAdapter.hs
@@ -46,9 +46,9 @@ outEdges :: (I.Graph g) => VertexLabeledGraph g nl -> I.Vertex -> [I.Edge]
 outEdges (VLG lg) = I.outEdges lg
 {-# INLINE outEdges #-}
 
-edgeExists :: (I.Graph g) => VertexLabeledGraph g nl -> I.Vertex -> I.Vertex -> Bool
-edgeExists (VLG lg) = I.edgeExists lg
-{-# INLINE edgeExists #-}
+edgesBetween :: (I.Graph g) => VertexLabeledGraph g nl -> I.Vertex -> I.Vertex -> [I.Edge]
+edgesBetween (VLG lg) = I.edgesBetween lg
+{-# INLINE edgesBetween #-}
 
 maxVertexId :: (I.Graph g) => VertexLabeledGraph g nl -> Int
 maxVertexId = I.maxVertexId . unVLG
@@ -63,7 +63,7 @@ instance (I.Graph g) => I.Graph (VertexLabeledGraph g nl) where
   edges = edges
   successors = successors
   outEdges = outEdges
-  edgeExists = edgeExists
+  edgesBetween = edgesBetween
   maxVertexId = maxVertexId
   isEmpty = isEmpty
 


### PR DESCRIPTION
Previously, `edgeExists` could be used to check whether there was an edge between two vertices. But it is often convenient to be able to get access to those edges. That was already possible by filtering the output of `outEdges`, but most of the representations in this package offer a more efficient way to get at those edges. This patch makes it possible.

The old `edgeExists` is still around, but has moved out of the class; it simply checks whether the list of edges produced by the new `edgesBetween` is empty or not -- and all of the existing instances are lazy enough that this should be no less efficient.