### PR TITLE
Fix a bug in the BiDigraph that prevented parallel edges

### DIFF
--- a/src/Data/Graph/Haggle/BiDigraph.hs
+++ b/src/Data/Graph/Haggle/BiDigraph.hs
@@ -137,10 +137,9 @@ instance MAddVertex MBiDigraph where
 
 
 instance MAddEdge MBiDigraph where
-  addEdge g v1@(V src) v2@(V dst) = do
+  addEdge g (V src) (V dst) = do
     nVerts <- R.readRef (mgraphVertexCount g)
-    exists <- checkEdgeExists g v1 v2
-    case exists || src >= nVerts || dst >= nVerts of
+    case src >= nVerts || dst >= nVerts of
       True -> return Nothing
       False -> do
         eid <- R.readRef (mgraphEdgeIdSrc g)


### PR DESCRIPTION
This removes an erroneous existence check on the addEdge implementation for BiDigraph that prevented the addition of duplicate (parallel) edges.