### PR TITLE
PatriciaTree self-edges

### DIFF
--- a/haggle.cabal
+++ b/haggle.cabal
@@ -1,5 +1,5 @@
 name: haggle
-version: 0.2.0.0.99
+version: 0.2.0.0.100
 synopsis: A graph library offering mutable, immutable, and inductive graphs
 description: This library provides mutable (in ST or IO), immutable, and inductive graphs.
              There are multiple graphs implementations provided to support different use

--- a/src/Data/Graph/Haggle/PatriciaTree.hs
+++ b/src/Data/Graph/Haggle/PatriciaTree.hs
@@ -120,6 +120,14 @@ instance I.InductiveGraph (PatriciaTree nl el) where
         v = I.V vid
         g' = IM.insert vid (Ctx mempty v lab mempty) g
     in (v, Gr g')
+  insertLabeledEdge gr@(Gr g) v1@(I.V src) (I.V dst) lab | src == dst = do
+    guard (IM.member src g)
+    guard (not (I.edgeExists gr v1 v1))
+    let e = I.E (-1) src src
+    Ctx spp sv sl sss <- IM.lookup src g
+    let ctx' = Ctx (IM.insert src lab spp) sv sl (IM.insert dst lab sss)
+        !g' = IM.insert src ctx' g
+    return (e, Gr g')
   insertLabeledEdge gr@(Gr g) v1@(I.V src) v2@(I.V dst) lab = do
     guard (IM.member src g && IM.member dst g)
     guard (not (I.edgeExists gr v1 v2))
@@ -132,6 +140,11 @@ instance I.InductiveGraph (PatriciaTree nl el) where
         !g'' = IM.insert dst dctx' g'
     return (e, Gr g'')
   deleteEdge g (I.E _ s d) = I.deleteEdgesBetween g (I.V s) (I.V d)
+  deleteEdgesBetween gr@(Gr g) (I.V src) (I.V dst) | src == dst = fromMaybe gr $ do
+    Ctx spp sv sl sss <- IM.lookup src g
+    let ctx' = Ctx (IM.delete src spp) sv sl (IM.delete src sss)
+        !g' = IM.insert src ctx' g
+    return (Gr g')
   deleteEdgesBetween gr@(Gr g) (I.V src) (I.V dst) = fromMaybe gr $ do
     Ctx spp sv sl sss <- IM.lookup src g
     Ctx dpp dv dl dss <- IM.lookup dst g

--- a/tests/GraphTests.hs
+++ b/tests/GraphTests.hs
@@ -213,6 +213,15 @@ testExplicit =
        do HGL.dominators gr2 (vs !! 0) @?= [ (vs !! 0, [ (vs !! 0) ])
                                            ]
 
+     , "haggle add self-edge" ~:
+       do let Just (e,g) = HGL.insertLabeledEdge gr0 (vs!!0) (vs!!0) 's'
+          HGL.edges g @?= [e]
+
+     , "haggle delete self-edge" ~:
+       do let Just (_,g) = HGL.insertLabeledEdge gr0 (vs!!0) (vs!!0) 's'
+          HGL.edges (HGL.deleteEdgesBetween g (vs!!0) (vs!!0)) @?= []
+
+
      -- n.b. fgl's dominator is broken (as haggle's original version also was) in
      -- that its return includes (4, [1,2,4]), which is invalid: 4 is in an
      -- independent subgraph and cannot be dominated by 1.


### PR DESCRIPTION
Insertion and deletion of a self-edge in a PatriciaTree is not reflected in the subsequent `edges` result.  This adds tests to demonstrate the issue, as well as provides a fix for the issue.