### PR TITLE
Add `replaceLabeledVertex` to InductiveGraph to complement `replaceLabeledEdge`

### DIFF
--- a/src/Data/Graph/Haggle.hs
+++ b/src/Data/Graph/Haggle.hs
@@ -157,6 +157,7 @@ module Data.Graph.Haggle (
   deleteEdge,
   deleteEdgesBetween,
   replaceLabeledEdge,
+  replaceLabeledVertex,
   deleteVertex,
   I.Context(..),
 
@@ -379,6 +380,10 @@ deleteEdgesBetween = I.deleteEdgesBetween
 replaceLabeledEdge :: (I.InductiveGraph g, I.Graph g, I.HasEdgeLabel g, I.HasVertexLabel g) => g -> I.Vertex -> I.Vertex -> I.EdgeLabel g -> Maybe (I.Edge, g)
 replaceLabeledEdge = I.replaceLabeledEdge
 {-# INLINABLE replaceLabeledEdge #-}
+
+replaceLabeledVertex :: (I.InductiveGraph g, I.Graph g, I.HasEdgeLabel g, I.HasVertexLabel g) => g -> I.Vertex -> I.VertexLabel g -> g
+replaceLabeledVertex = I.replaceLabeledVertex
+{-# INLINABLE replaceLabeledVertex #-}
 
 deleteVertex :: (I.InductiveGraph g, I.Graph g, I.HasEdgeLabel g, I.HasVertexLabel g) => g -> I.Vertex -> g
 deleteVertex = I.deleteVertex

--- a/src/Data/Graph/Haggle/Classes.hs
+++ b/src/Data/Graph/Haggle/Classes.hs
@@ -208,6 +208,10 @@ class (Graph g, HasEdgeLabel g, HasVertexLabel g) => InductiveGraph g where
     let g' = deleteEdgesBetween g src dst
     in insertLabeledEdge g' src dst lbl
 
+  -- | Used to update the label for a Vertex.  The Vertex itself remains, but the
+  -- label associated with the vertex is modified.
+  replaceLabeledVertex :: g -> Vertex -> VertexLabel g -> g
+
   -- | Remove a 'Vertex' from the graph
   deleteVertex :: g -> Vertex -> g
   deleteVertex g v = fromMaybe g $ do

--- a/src/Data/Graph/Haggle/PatriciaTree.hs
+++ b/src/Data/Graph/Haggle/PatriciaTree.hs
@@ -120,6 +120,9 @@ instance I.InductiveGraph (PatriciaTree nl el) where
         v = I.V vid
         g' = IM.insert vid (Ctx mempty v lab mempty) g
     in (v, Gr g')
+  replaceLabeledVertex (Gr g) (I.V v) vl =
+    let updLabel (Ctx ie nv _nl oe) = Ctx ie nv vl oe
+    in Gr $ IM.adjust updLabel v g
   insertLabeledEdge gr@(Gr g) v1@(I.V src) (I.V dst) lab | src == dst = do
     guard (IM.member src g)
     guard (not (I.edgeExists gr v1 v1))

--- a/tests/GraphTests.hs
+++ b/tests/GraphTests.hs
@@ -272,4 +272,11 @@ testPatricia =
        do let gr2 = Bi.bimap (+2) (succ . succ) gr1
           sum (snd <$> HGL.labeledVertices gr2) @?= 27
           L.sort (snd <$> HGL.labeledEdges gr2) @?= "cde"
+
+     , "replaceLabeledVertex" ~:
+       do let gr2 = HGL.replaceLabeledVertex gr1 (vs !! 2) 11
+          -- Vertex label changed?
+          sum (snd <$> HGL.labeledVertices gr2) @?= (15 + (11 - 4))
+          -- Edges are still in place?
+          L.sort (snd <$> HGL.labeledEdges gr2) @?= "abc"
      ]


### PR DESCRIPTION
It's possible that this should only be a function for a `PatriciaTree` and not a general `InductiveGraph` operation, but since `PatriciaTree` is currently the only `InductiveGraph` I left it as a Class-level function.