### PR TITLE
Support building with GHC 9.6

### DIFF
--- a/haggle.cabal
+++ b/haggle.cabal
@@ -43,7 +43,7 @@ library
                  Data.Graph.Haggle.Internal.BitSet
   build-depends: base >= 4.5 && < 5,
                  ref-tf >= 0.4 && < 0.6,
-                 vector >= 0.9 && < 0.13,
+                 vector >= 0.9 && < 0.14,
                  vector-th-unbox >= 0.2.1.3 && < 0.3,
                  primitive >= 0.4 && < 0.9,
                  containers >= 0.4,

--- a/haggle.cabal
+++ b/haggle.cabal
@@ -48,8 +48,7 @@ library
                  primitive >= 0.4 && < 0.9,
                  containers >= 0.4,
                  hashable >= 1.2 && < 1.5,
-                 deepseq >= 1 && < 2,
-                 monad-primitive < 0.2
+                 deepseq >= 1 && < 2
 
 test-suite GraphTests
   type: exitcode-stdio-1.0

--- a/src/Data/Graph/Haggle/PatriciaTree.hs
+++ b/src/Data/Graph/Haggle/PatriciaTree.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE TypeFamilies, BangPatterns #-}
+{-# LANGUAGE TypeFamilies, BangPatterns, DeriveFunctor #-}
 -- | This graph is based on the implementation in fgl (using
 -- big-endian patricia-tries -- IntMap).
 --
@@ -20,6 +20,7 @@ import qualified Data.Graph.Haggle.Classes as I
 import qualified Data.Graph.Haggle.Internal.Basic as I
 
 data Ctx nl el = Ctx !(IntMap el) I.Vertex nl !(IntMap el)
+  deriving Functor
 
 instance (NFData nl, NFData el) => NFData (Ctx nl el) where
   rnf (Ctx p v nl s) =
@@ -37,6 +38,7 @@ instance (NFData nl, NFData el) => NFData (Ctx nl el) where
 -- This graph type is most useful for incremental construction in pure
 -- code.  It also supports node removal from pure code.
 data PatriciaTree nl el = Gr { graphRepr :: IntMap (Ctx nl el) }
+  deriving Functor
 
 instance (NFData nl, NFData el) => NFData (PatriciaTree nl el) where
   rnf (Gr im) = im `deepseq` ()


### PR DESCRIPTION
Three small patches needed for GHC 9.6 support:

## Remove unused `monad-primitive` dependency

`monad-primitive` no longer builds with `transformers-0.6.*` (bundled with GHC 9.6), so removing this dependency is important for 9.6 support.

## Allow building with `vector-0.13.*`

## Add `Functor` instances for `PatriciaTree` and `Ctx`

`Bifunctor` now has a quantified `Functor` superclass in recent versions of `base`, so we need to define a `Functor` instance for `PatriciaTree` to go along with its existing `Bifunctor` instance. The easiest way to do so is via `DeriveFunctor`. This entails deriving a `Functor` instance for `Ctx` (on top of which `PatriciaTree` is defined) as well.