### PR TITLE
Bump upper version bounds to allow building with GHC 9.10

### DIFF
--- a/haggle.cabal
+++ b/haggle.cabal
@@ -45,9 +45,9 @@ library
                  ref-tf >= 0.4 && < 0.6,
                  vector >= 0.9 && < 0.14,
                  vector-th-unbox >= 0.2.1.3 && < 0.3,
-                 primitive >= 0.4 && < 0.9,
+                 primitive >= 0.4 && < 0.10,
                  containers >= 0.4,
-                 hashable >= 1.2 && < 1.5,
+                 hashable >= 1.2 && < 1.6,
                  deepseq >= 1 && < 2
 
 test-suite GraphTests
@@ -75,7 +75,7 @@ benchmark haggleBench
   ghc-options: -Wall -O2
   build-depends: haggle
                , base >= 4.5
-               , criterion >= 1 && < 1.6
+               , criterion >= 1 && < 1.7
                , containers
                , deepseq
                , fgl >= 5.8.1.1


### PR DESCRIPTION
This bumps the upper version bounds on `criterion`, `hashable`, and `primitive` to pick a build plan that is compatible with GHC 9.10.